### PR TITLE
Add Terraform configuration for ECS cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ access_key = "YOUR_AWS_ACCESS_KEY_ID"
 secret_key = "YOUR_AWS_SECRET_ACCESS_KEY"
 key_name   = "YOUR_AWS_EC2_KEY_PAIR_NAME"
 ```
-3. Run `terraform plan` to see what resources will be created and then `terraform apply` to create the resources. Enter
+3. Run `terraform init` to initialize the Terraform working directory.
+4. Run `terraform plan` to see what resources will be created and then `terraform apply` to create the resources. Enter
 `yes` when prompted by Terraform.
-4. Once the previous command is done running, the AWS resources should now be visible in the AWS console (UI) and ready
+5. Once the previous command is done running, the AWS resources should now be visible in the AWS console (UI) and ready
 to be used for development/testing. Once you're done using the resources, run `terraform destroy`. Enter `yes` when
 prompted by Terraform.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 an AWS EC2 key pair which you will need to be able to SSH into the EC2 instance(s).
 2. Create a file in the root of this repo called `terraform.tfvars` and fill it out like this:
 ```
+name = "WHATEVER_UNIQUE_NAME_YOU_WANT"
 access_key = "YOUR_AWS_ACCESS_KEY_ID"
 secret_key = "YOUR_AWS_SECRET_ACCESS_KEY"
 key_name   = "YOUR_AWS_EC2_KEY_PAIR_NAME"

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,41 @@ provider "aws" {
   region     = var.region
 }
 
-resource "aws_instance" "example" {
-  ami           = "ami-00bf61217e296b409"
-  instance_type = "t2.micro"
-  key_name      = var.key_name
+resource "aws_ecs_cluster" "riht" {
+  name = var.name
+}
+
+resource "aws_iam_role" "ecs_agent" {
+  name = "${var.name}_ecs_instance_role"
+  path = "/ecs/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "ecs_agent" {
+  name = "${var.name}_ecs_instance_profile"
+  role = aws_iam_role.ecs_agent.name
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_agent_role" {
+  role = aws_iam_role.ecs_agent.id
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_agent_cloudwatch_role" {
+  role = aws_iam_role.ecs_agent.id
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
 }

--- a/main.tf
+++ b/main.tf
@@ -42,3 +42,80 @@ resource "aws_iam_role_policy_attachment" "ecs_agent_cloudwatch_role" {
   role = aws_iam_role.ecs_agent.id
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
 }
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws" # 3rd party module
+  version = "~> 2.0"
+
+  name = var.name
+
+  cidr = "10.1.0.0/16"
+
+  # TODO: Don't hard code these three arguments
+  azs             = ["us-east-2a", "us-east-2b"]
+  private_subnets = ["10.1.1.0/24", "10.1.2.0/24"]
+  public_subnets  = ["10.1.11.0/24", "10.1.12.0/24"]
+
+  enable_nat_gateway = true
+
+  tags = {
+    Name = var.name
+  }
+}
+
+data "aws_ami" "amazon_linux_ecs" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-*-amazon-ecs-optimized"]
+  }
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+}
+
+module "autoscaling" {
+  source  = "terraform-aws-modules/autoscaling/aws" # 3rd party module
+  version = "~> 3.0"
+
+  name = var.name
+
+  # Launch configuration
+  lc_name = "${var.name}_launch_configuration"
+
+  image_id             = data.aws_ami.amazon_linux_ecs.id
+  instance_type        = "t2.micro"
+  security_groups      = [module.vpc.default_security_group_id]
+  iam_instance_profile = aws_iam_instance_profile.ecs_agent.id
+  user_data            = data.template_file.user_data.rendered
+
+  # Auto scaling group
+  asg_name                  = "${var.name}_asg"
+  vpc_zone_identifier       = module.vpc.private_subnets
+  health_check_type         = "EC2"
+  min_size                  = 0
+  max_size                  = 1
+  desired_capacity          = 1
+  wait_for_capacity_timeout = 0
+
+  tags = [
+    {
+      key                 = "Cluster"
+      value               = var.name
+      propagate_at_launch = true
+    },
+  ]
+}
+
+data "template_file" "user_data" {
+  template = file("${path.module}/user_data.sh")
+
+  vars = {
+    cluster_name = var.name
+  }
+}

--- a/user_data.sh
+++ b/user_data.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# ECS config
+echo "ECS_CLUSTER=${cluster_name}" >> /etc/ecs/ecs.config
+
+echo "Done"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,4 @@
+variable "name" {}
 variable "access_key" {}
 variable "secret_key" {}
 variable "region" {


### PR DESCRIPTION
Resolves #1 

Mostly based on these two examples: [Setting up ECS with Terraform](https://blog.ulysse.io/post/setting-up-ecs-with-terraform/) and [Complete ECS](https://github.com/terraform-aws-modules/terraform-aws-ecs/tree/master/examples/complete-ecs).

The `module` blocks are 3rd party Terraform modules that define the configuration for more complicated stuff like Virtual Private Clouds (VPC) and Auto Scaling Groups that require a bunch of configuration, so using the modules simplifies things.

In terms of ECS, this configuration sets up an ECS cluster with no services and EC2 instances that will join the cluster on startup. The VPC is needed as a place for the EC2 instances to live, and the Auto Scaling Group is needed so that the number of EC2 instances can grow or shrink automatically based on a given metric (like CPU usage).